### PR TITLE
Migrate to CMake and re-oganize code.

### DIFF
--- a/disas/CMakeLists.txt
+++ b/disas/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+project(disas C)
+
+set(CMAKE_C_STANDARD 14)
+
+# Add the source files
+set(SOURCES
+    MAIN.c
+    fileutils.c
+)
+
+# Add the header files for IDEs
+set(HEADERS
+    defs.h
+    magic.h
+    logging.h
+    arch.h
+    fileutils.h
+    x86_64.h
+)
+
+add_executable(disas ${SOURCES} ${HEADERS})
+
+target_include_directories(disas PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/disas/MAIN.c
+++ b/disas/MAIN.c
@@ -1,79 +1,50 @@
 #include "magic.h"
 #include "defs.h"
 #include "logging.h"
+#include "arch.h"
 #include <stdio.h>
+#include <string.h>
+#include "fileutils.h"
 
-#if (defined(__GNUC__))
-// GNU defines the architecture macro different that MSVC.
-#	if (defined(__x86_64__))
-		// By default, ARCH is set to x86_64. Just include the header.
-#		include "x86_64.h"
-#	elif (defined(__i386__))
-#		include "i386.h"
-#		undef ARCH
-#		define ARCH		ARCH_I386
-#	elif (defined(__arm__))
-#		error ARM support is comming soon.
-#	else
-#		error Unsupported architecture.
-#	endif
-#elif (defined(_MSC_VER))
-#	if (defined(_M_X64))
-		// By default, ARCH is set to x86_64.	
-#	elif (defined(_M_IX86)
-#		undef ARCH
-#		define ARCH		ARCH_I386
-#	elif (defined(_M_ARM)
-#		error ARM support is comming soon.
-#	else
-#		error Unsupported architecture.
-#	endif
-#else
-#	error Unsupported compiler.
-#endif
-
-void set_infile_with_path(string_t path)
+int INTERNAL main(U16 argc, string_t argv[])
 {
-	FILE* fp = fopen(path, "rb");
+    printf("This is `disas` version %s for x86_%d.\n", VER, (int)ARCH);
+    puts("USE OF THIS SOFTWARE FOR NON-AUTHORIZED PURPOSES IS ILLEGAL AND PUNISHABLE BY LAW.\n");
 
-	if (!fp) {
-		error(1, "Cannot open file: %s\n", path);
-	}
+    if (argc < 2)
+        error(2, "No input file specified. Usage: %s [-h|-v] FILE\n", argv[0]);
 
-	infile = fp;
-}
+    if (argv[1][0] == '-') {
+        switch (argv[1][1]) {
+            case '?':
+                printf("Usage: %s [-h|-v] FILE\n", argv[0]);
+                puts("Options:");
+                puts("  -?    Show this help message.");
+                puts("  -v    Show version information.");
+                puts("  FILE  The file to disassemble.");
+                puts("Further help can be found on the README.md file bundled with the program, or on the GitHub repo (mar1lusk1/disas).");
+                return 0;
+            case 'v':
+                printf("Version: %s\n", VER);
+                return 0;
+            default:
+                error(2, "Unknown option: %s\n", argv[1]);
+        }
+    }
 
-int INTERNAL
-main(U16 argc, string_t argv[])
-{
-	printf("This is `disas` version %s for x86_%d.\n", VER, (int)ARCH);
-	puts("USE OF THIS SOFTWARE FOR NON-AUTHORIZED PURPOSES \
-IS ILLEGAL AND PUNISHABLE BY LAW.\n");
+    FILE* infile_ptr = fopen(argv[1], "rb");
+    if (!infile_ptr) {
+        error(1, "Cannot open file: %s.\n", argv[1]);
+    }
 
-	if (argc < 2)
-		error(2, "No input file specified. Usage: %s [-h|-v] FILE\n", argv[0]);
+    unsigned char buf[2048] = {0};
+    size_t bytes_read = fread(buf, 1, sizeof(buf), infile_ptr);
+    fclose(infile_ptr);
 
-	if (argv[1][0] == '-') { // If cmdarg starts with a dash, then it's a flag
-		switch (argv[1][1]) {
-			case 'h':
-				printf("Usage: %s [-h|-v] FILE\n", argv[0]);
-				puts("Options:");
-				puts("  -h    Show this help message.");
-				puts("  -v    Show version information.");
-				puts("  FILE  The file to disassemble.");
-				puts ("Further help can be found on the README.md file bundled\
-with the program, or on the GitHub repo (mar1lusk1/disas).");
-		
-				return 0;
-			case 'v':
-				printf("Version: %s\n", VER);
-				return 0;
-			default:
-				error(2, "Unknown option: %s\n", argv[1]);
-		}
-	}
+    remove_magic((string_t)buf);
 
-	// If we reach here, then we have a file to disassemble.
-
+    printf("file, no headers:\n");
+    printf("%s\n", buf);
+    return 0;
 }
 

--- a/disas/arch.h
+++ b/disas/arch.h
@@ -1,0 +1,33 @@
+#ifndef ARCH_H
+#define ARCH_H
+
+#include "defs.h"
+
+// Architecture detection and macros
+#if defined(__GNUC__)
+    #if defined(__x86_64__)
+        #define ARCH ARCH_X86_64
+        #include "x86_64.h"
+    #elif defined(__i386__)
+        #define ARCH ARCH_I386
+        // #include "i386.h" // Uncomment if you have i386.h
+    #elif defined(__arm__)
+        #error ARM support is coming soon.
+    #else
+        #error Unsupported architecture.
+    #endif
+#elif defined(_MSC_VER)
+    #if defined(_M_X64)
+        #define ARCH ARCH_X86_64
+    #elif defined(_M_IX86)
+        #define ARCH ARCH_I386
+    #elif defined(_M_ARM)
+        #error ARM support is coming soon.
+    #else
+        #error Unsupported architecture.
+    #endif
+#else
+    #error Unsupported compiler.
+#endif
+
+#endif // ARCH_H

--- a/disas/defs.h
+++ b/disas/defs.h
@@ -2,7 +2,7 @@
 #	define __DEFS_H__
 #	include <stdio.h>
 
-#		define VER "0.0.1 dev"
+#	define VER "0.0.1 dev"
 
 	enum arch_t {
 		ARCH_X86_64 = 64,
@@ -17,7 +17,7 @@
 	typedef char*				string_t;
 	typedef U8					bool_t;
 
-	FILE* INTERNAL infile;
+	extern FILE* infile;
 
 #		define ARCH		ARCH_X86_64
 	

--- a/disas/disas.vcxproj
+++ b/disas/disas.vcxproj
@@ -128,12 +128,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="fileutils.c" />
     <ClCompile Include="MAIN.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="arch.h" />
     <ClInclude Include="defs.h" />
+    <ClInclude Include="fileutils.h" />
     <ClInclude Include="logging.h" />
     <ClInclude Include="magic.h" />
+    <ClInclude Include="x86_64.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/disas/disas.vcxproj.filters
+++ b/disas/disas.vcxproj.filters
@@ -13,9 +13,15 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Tables">
+      <UniqueIdentifier>{9b9e653e-f3ce-4aeb-b1fc-5b475d61cf99}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MAIN.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fileutils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -29,5 +35,17 @@
     <ClInclude Include="logging.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="x86_64.h">
+      <Filter>Tables</Filter>
+    </ClInclude>
+    <ClInclude Include="arch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fileutils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/disas/fileutils.c
+++ b/disas/fileutils.c
@@ -1,0 +1,41 @@
+#include "fileutils.h"
+#include "logging.h"
+#include "arch.h"
+#include <stdio.h>
+
+FILE* infile = NULL;
+
+void set_infile_with_path(string_t path)
+{
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        error(1, "Cannot open file: %s\n", path);
+    }
+    infile = fp;
+}
+
+void remove_magic(const string_t str)
+{
+    // Check for ELF magic: 0x7F 'E' 'L' 'F'.
+    if (str && (unsigned char)str[0] == 0x7F && str[1] == 'E' && str[2] == 'L' && str[3] == 'F') {
+        if (ARCH == ARCH_X86_64) {
+            for (int i = 0; i < 0x40; ++i)
+                str[i] = 0;
+        }
+        else if (ARCH == ARCH_I386) {
+            for (int i = 0; i < 0x34; ++i)
+                str[i] = 0;
+        }
+        return;
+    }
+    // Now the MS PE one. It starts with 0x4D 0x5A ('MZ').
+    if (str && (unsigned char)str[0] == 0x4D && str[1] == 0x5A) {
+        for (int i = 0; i < 0x40; ++i)
+            str[i] = 0;
+        unsigned int pe_offset = *(const unsigned int *)(str + 0x3C);
+        unsigned int pe_struct_size = (ARCH == ARCH_X86_64) ? 264 : 248;
+        unsigned int end = pe_offset + pe_struct_size;
+        for (unsigned int i = 0; i < end; ++i)
+            str[i] = 0;
+    }
+}

--- a/disas/fileutils.h
+++ b/disas/fileutils.h
@@ -1,0 +1,10 @@
+#ifndef FILEUTILS_H
+#define FILEUTILS_H
+
+#include "defs.h"
+#include <stdio.h>
+
+void set_infile_with_path(string_t path);
+void remove_magic(const string_t str);
+
+#endif // FILEUTILS_H

--- a/disas/logging.h
+++ b/disas/logging.h
@@ -5,6 +5,7 @@
 #		include "defs.h"
 #		include <stdio.h>
 #		include <stdarg.h>
+#		include <stdlib.h>
 
 	static inline void INTERNAL
 	error(U8 ecode, const string_t fmt, ...)
@@ -18,4 +19,4 @@
 		if (ecode > 0) { exit(ecode); }
 	}
 
-#endif /* __LOGGING_H */
+#endif /* __LOGGING_H__ */

--- a/disas/x86_64.h
+++ b/disas/x86_64.h
@@ -1,0 +1,8 @@
+#ifndef __TABLE_X86_64__
+#	define __TABLE_X86_64__
+
+#	include "defs.h"
+
+const string_t table[] ={"mov",}
+
+#endif /*__TABLE_X86_64__ */


### PR DESCRIPTION
Refactored architecture handling and improve file management

- Added `arch.h` for centralized architecture detection.
- Moved `set_infile_with_path` and `remove_magic` to `fileutils.c`.
- Updated command-line argument handling in `MAIN.c`.
- Corrected `VER` definition in `defs.h`.
- Updated project files to include new source/header files.
- Created `CMakeLists.txt` for CMake build support.
- Enhanced `logging.h` with proper header guards and includes.
- Introduced `x86_64.h` for architecture-specific definitions.